### PR TITLE
fix(client/main.lua): society car spawning

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -88,7 +88,7 @@ function OpenMechanicActionsMenu()
 
 					ESX.OpenContext("right", elements2, function(menu2,element2)
 						ESX.CloseContext()
-						local vehicleProps = element.value
+						local vehicleProps = element2.value
 
 						ESX.Game.SpawnVehicle(vehicleProps.model, Config.Zones.VehicleSpawnPoint.Pos, 270.0, function(vehicle)
 							ESX.Game.SetVehicleProperties(vehicle, vehicleProps)


### PR DESCRIPTION
fix if Config.EnableSocietyOwnedVehicles is true.
Bug: not spawning the selected car correctly